### PR TITLE
forecast.solar: persist cache across restarts

### DIFF
--- a/docs/configuration/solar-forecast.md
+++ b/docs/configuration/solar-forecast.md
@@ -25,7 +25,9 @@ pvinstallations:
 ```
 The **name** must be a unique value.
 
-If a solar forecast provider is not available, batcontrol is running on cached values. It stops working if less then 12 hours of forecast are available. That should be enough to overcome outages.
+If a solar forecast provider is unavailable, batcontrol continues with cached values. Cache entries are usable while their age is strictly less than 12 hours. At 12 hours they expire and the existing no-data behavior applies.
+
+For Forecast.Solar, the latest successful raw response for each installation is also saved to the `forecast_cache` directory beside the selected batcontrol configuration file. This restart cache retains the original fetch timestamp, so restarting batcontrol does not renew its age. Files are atomically replaced, limited to the current response, and written with owner-only (`0600`) permissions. Missing, stale, malformed, or unwritable files do not prevent batcontrol from using its in-memory cache or its normal no-data fallback.
 
 
 ## Forecast.Solar (Default)

--- a/src/batcontrol/__main__.py
+++ b/src/batcontrol/__main__.py
@@ -1,17 +1,26 @@
-from .core import Batcontrol
-from .setup import setup_logging, load_config
-from .inverter import InverterOutageError
+"""Command-line entry point for batcontrol."""
+
 import argparse
-import time
 import datetime
-import sys
 import logging
+from pathlib import Path
+import sys
+import time
+
+from .core import Batcontrol
+from .inverter import InverterOutageError
+from .setup import setup_logging, load_config
 
 
 CONFIGFILE = "config/batcontrol_config.yaml"
 EVALUATIONS_EVERY_MINUTES = 3  # Every x minutes on the clock
 LOGFILE_ENABLED_DEFAULT = True
 LOGFILE = "logs/batcontrol.log"
+
+
+def get_forecast_cache_directory(config_file):
+    """Return the restart-cache directory associated with a config file."""
+    return Path(config_file).resolve().parent / "forecast_cache"
 
 
 def parse_arguments():
@@ -78,7 +87,10 @@ def main() -> int:
         logging.getLogger("batcontrol.forecastconsumption.forecast_homeassistant.details").setLevel(logging.INFO)
         logging.getLogger("batcontrol.forecastconsumption.forecast_homeassistant.communication").setLevel(logging.INFO)
 
-    bc = Batcontrol(config)
+    bc = Batcontrol(
+        config,
+        forecast_cache_directory=get_forecast_cache_directory(args.config),
+    )
 
     try:
         while True:

--- a/src/batcontrol/core.py
+++ b/src/batcontrol/core.py
@@ -120,7 +120,7 @@ class Batcontrol:
     """ Main class for Batcontrol, handles the logic and control of the battery system """
     general_logic = None  # type: CommonLogic
 
-    def __init__(self, configdict: dict):
+    def __init__(self, configdict: dict, forecast_cache_directory=None):
         # For API
         self.api_overwrite = False
         # -1 = charge from grid , 0 = avoid discharge , 8 = limit battery charge, 10 = discharge allowed
@@ -252,7 +252,8 @@ class Batcontrol:
             DELAY_EVALUATION_BY_SECONDS,
             requested_provider=config.get(
                 'solar_forecast_provider', 'fcsolarapi'),
-            target_resolution=self.time_resolution
+            target_resolution=self.time_resolution,
+            persistent_cache_directory=forecast_cache_directory,
         )
 
         self.fc_consumption = consumption_factory.create_consumption(

--- a/src/batcontrol/fetcher/relaxed_caching.py
+++ b/src/batcontrol/fetcher/relaxed_caching.py
@@ -7,10 +7,15 @@ The RelaxedCaching class uses Python's cachetools library (TTLCache) for efficie
 caching with automatic expiration and size management.
 """
 
-import time
+import json
 import logging
+import math
+import os
+from pathlib import Path
 import threading
-from typing import Any, Optional
+import time
+from typing import Any, Callable, Optional
+
 from cachetools import TTLCache
 
 logger = logging.getLogger(__name__)
@@ -20,14 +25,37 @@ class CacheMissError(RuntimeError):
     """Exception raised when attempting to retrieve a cache entry that doesn't exist"""
 
 
+def _decode_persisted_entry(document: Any, now: float, ttl_seconds: int):
+    """Validate an on-disk entry and return its original timestamp and data."""
+    if not isinstance(document, dict):
+        raise CacheMissError('Persisted cache document is not an object')
+    if 'stored_at' not in document or 'data' not in document:
+        raise CacheMissError('Persisted cache document is incomplete')
+
+    stored_at = document['stored_at']
+    if isinstance(stored_at, bool) or not isinstance(stored_at, (int, float)):
+        raise CacheMissError('Persisted cache timestamp is invalid')
+    if not math.isfinite(stored_at):
+        raise CacheMissError('Persisted cache timestamp is invalid')
+
+    age = now - float(stored_at)
+    if age < 0:
+        raise CacheMissError('Persisted cache timestamp is in the future')
+    if age >= ttl_seconds:
+        raise CacheMissError('Persisted cache entry has expired')
+
+    return float(stored_at), document['data']
+
+
 class RelaxedCaching:
     """Thread-safe caching mechanism with TTL support using cachetools.TTLCache
 
     This class provides a caching layer for API providers with the following features:
     - Thread-safe operations using locks
     - Automatic cache size management via TTLCache (keeps max N entries)
-    - TTL-based cache expiration (default: 18 hours) via TTLCache
+    - TTL-based cache expiration (default: 12 hours) via TTLCache
     - Timestamp-based entry keys
+    - Optional atomic persistence of the newest entry across restarts
 
     Attributes:
         entry_key (Optional[float]): Timestamp of the last stored entry, None if cache is empty
@@ -36,19 +64,35 @@ class RelaxedCaching:
         max_entries (int): Maximum number of entries to keep in cache (default: 2)
     """
 
-    def __init__(self, ttl_hours: float = 12.0, max_entries: int = 2):
+    def __init__(
+            self,
+            ttl_hours: float = 12.0,
+            max_entries: int = 2,
+            persistence_path=None,
+            wall_clock: Callable[[], float] = time.time,
+    ):
         """Initialize the RelaxedCaching instance
 
         Args:
             ttl_hours (float): Time-to-live for cache entries in hours (default: 12.0)
             max_entries (int): Maximum number of entries to keep in cache (default: 2)
+            persistence_path: Optional JSON file for the newest cache entry
+            wall_clock: Injectable epoch clock used for restart-safe age checks
         """
         self.entry_key: Optional[float] = None
         self.ttl_seconds: int = int(ttl_hours * 3600)
         self.max_entries: int = max_entries
+        self._persistence = (
+            Path(persistence_path) if persistence_path is not None else None,
+            wall_clock,
+        )
+        self._entry_loaded_from_disk = False
 
         # Use cachetools.TTLCache for automatic TTL and size management
-        self.cache_store: TTLCache = TTLCache(maxsize=max_entries, ttl=self.ttl_seconds)
+        self.cache_store: TTLCache = TTLCache(
+            maxsize=max_entries,
+            ttl=self.ttl_seconds,
+        )
         self._lock = threading.Lock()
 
         logger.debug(
@@ -57,6 +101,70 @@ class RelaxedCaching:
             ttl_hours,
             max_entries
         )
+        self._load_persisted_entry()
+
+    def _load_persisted_entry(self) -> None:
+        """Load a fresh restart entry, treating every file problem as a miss."""
+        persistence_path, wall_clock = self._persistence
+        if persistence_path is None:
+            return
+
+        try:
+            with persistence_path.open('r', encoding='utf-8') as handle:
+                document = json.load(handle)
+            stored_at, data = _decode_persisted_entry(
+                document,
+                wall_clock(),
+                self.ttl_seconds,
+            )
+        except FileNotFoundError:
+            return
+        except (OSError, UnicodeError, json.JSONDecodeError, CacheMissError):
+            logger.warning('Ignoring unusable persisted cache entry')
+            return
+
+        self.cache_store[stored_at] = data
+        self.entry_key = stored_at
+        self._entry_loaded_from_disk = True
+        logger.info(
+            'Loaded persisted cache entry (%d seconds old)',
+            int(wall_clock() - stored_at),
+        )
+
+    def _persist_entry(self, stored_at: float, data: Any) -> None:
+        """Atomically replace the restart entry with owner-only permissions."""
+        persistence_path, _ = self._persistence
+        if persistence_path is None:
+            return
+
+        persistence_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        temporary_path = persistence_path.with_name(persistence_path.name + '.tmp')
+        document = {
+            'stored_at': stored_at,
+            'data': data,
+        }
+
+        descriptor = None
+        try:
+            descriptor = os.open(
+                temporary_path,
+                os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
+                0o600,
+            )
+            with os.fdopen(descriptor, 'w', encoding='utf-8') as handle:
+                descriptor = None
+                json.dump(document, handle, separators=(',', ':'))
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.chmod(temporary_path, 0o600)
+            os.replace(temporary_path, persistence_path)
+        finally:
+            if descriptor is not None:
+                os.close(descriptor)
+            try:
+                temporary_path.unlink()
+            except FileNotFoundError:
+                pass
 
     def get_last_entry(self) -> Any:
         """Retrieve the last cached entry
@@ -74,6 +182,15 @@ class RelaxedCaching:
             if self.entry_key is None:
                 logger.debug('Cache miss: entry_key is None')
                 raise CacheMissError('No cache entry available (entry_key is None)')
+
+            _, wall_clock = self._persistence
+            age = wall_clock() - self.entry_key
+            if self._entry_loaded_from_disk and (
+                    age < 0 or age >= self.ttl_seconds):
+                self.cache_store.pop(self.entry_key, None)
+                self.entry_key = None
+                self._entry_loaded_from_disk = False
+                raise CacheMissError('Cache entry has expired')
 
             # TTLCache automatically removes expired entries
             if self.entry_key not in self.cache_store:
@@ -102,13 +219,20 @@ class RelaxedCaching:
         """
         with self._lock:
             # Get current timestamp as key
-            timestamp = time.time()
+            _, wall_clock = self._persistence
+            timestamp = wall_clock()
 
             # Store the new entry (TTLCache handles size management automatically)
             self.cache_store[timestamp] = data
 
             # Update entry_key to point to the new entry (blocking operation for other threads)
             self.entry_key = timestamp
+            self._entry_loaded_from_disk = False
+
+            try:
+                self._persist_entry(timestamp, data)
+            except (OSError, TypeError, ValueError):
+                logger.warning('Could not persist cache entry')
 
             logger.debug(
                 'Stored new cache entry with key %s (total entries: %d)',
@@ -127,6 +251,17 @@ class RelaxedCaching:
             entries_count = len(self.cache_store)
             self.cache_store.clear()
             self.entry_key = None
+            self._entry_loaded_from_disk = False
+
+            persistence_path, _ = self._persistence
+            if persistence_path is not None:
+                try:
+                    persistence_path.unlink()
+                except FileNotFoundError:
+                    pass
+                except OSError:
+                    logger.warning('Could not remove persisted cache entry')
+
             logger.info('Cache cleared (%d entries removed)', entries_count)
 
     def get_cache_info(self) -> dict:
@@ -150,6 +285,7 @@ class RelaxedCaching:
             }
 
             if self.entry_key is not None:
-                info['cache_age_seconds'] = int(time.time() - self.entry_key)
+                _, wall_clock = self._persistence
+                info['cache_age_seconds'] = int(wall_clock() - self.entry_key)
 
             return info

--- a/src/batcontrol/forecastsolar/baseclass.py
+++ b/src/batcontrol/forecastsolar/baseclass.py
@@ -1,16 +1,27 @@
 """ Parent Class for implementing different solar forecast providers"""
 from abc import ABCMeta
 import datetime
+import hashlib
 import threading
 import time
 import random
 import logging
+from pathlib import Path
 from .forecastsolar_interface import ForecastSolarInterface
 from ..fetcher.relaxed_caching import RelaxedCaching, CacheMissError
 from ..scheduler import schedule_once
 from ..interval_utils import upsample_forecast, downsample_to_hourly
 
 logger = logging.getLogger(__name__)
+
+def _persistence_paths(pvinstallations: list, directory) -> dict:
+    """Map installation names to safe persistent cache paths."""
+    root = Path(directory)
+    return {
+        unit['name']: root /
+        f"{hashlib.sha256(unit['name'].encode('utf-8')).hexdigest()}.json"
+        for unit in pvinstallations
+    }
 
 
 class ProviderError(Exception):
@@ -42,7 +53,8 @@ class ForecastSolarBaseclass(ForecastSolarInterface):
     """
 
     def __init__(self, pvinstallations, timezone, min_time_between_API_calls,
-                 delay_evaluation_by_seconds, target_resolution=60, native_resolution=60) -> None:
+                 delay_evaluation_by_seconds, target_resolution=60, native_resolution=60,
+                 persistent_cache_directory=None) -> None:
         self.pvinstallations = pvinstallations
         self.next_update_ts = 0
         self.min_time_between_updates = min_time_between_API_calls
@@ -64,11 +76,21 @@ class ForecastSolarBaseclass(ForecastSolarInterface):
         )
 
         try:
-            for unit in pvinstallations:
-                name = unit['name']
-                self.cache_list[name] = RelaxedCaching()
+            installation_names = [unit['name'] for unit in pvinstallations]
         except KeyError as e:
             raise ValueError("Each PV installation must have a 'name' key") from e
+
+        persistence_paths = {}
+        if persistent_cache_directory is not None:
+            persistence_paths = _persistence_paths(
+                pvinstallations,
+                persistent_cache_directory,
+            )
+
+        for name in installation_names:
+            self.cache_list[name] = RelaxedCaching(
+                persistence_path=persistence_paths.get(name)
+            )
 
     def get_raw_data(self, pvinstallation_name) -> dict:
         """ Get raw data from cache or provider """

--- a/src/batcontrol/forecastsolar/fcsolar.py
+++ b/src/batcontrol/forecastsolar/fcsolar.py
@@ -24,7 +24,8 @@ class FCSolar(ForecastSolarBaseclass):
     """
 
     def __init__(self, pvinstallations, timezone,
-                 min_time_between_api_calls, api_delay=0, target_resolution=60):
+                 min_time_between_api_calls, api_delay=0, target_resolution=60,
+                 persistent_cache_directory=None):
         """ Initialize the FCSolar class 
 
         Args:
@@ -33,11 +34,17 @@ class FCSolar(ForecastSolarBaseclass):
             min_time_between_api_calls: Minimum seconds between API calls
             api_delay: Delay for API evaluation
             target_resolution: Target resolution in minutes (15 or 60)
+            persistent_cache_directory: Optional restart-cache directory
         """
-        super().__init__(pvinstallations, timezone,
-                         min_time_between_api_calls, api_delay,
-                         target_resolution=target_resolution,
-                         native_resolution=60)  # FCSolar provides hourly data
+        super().__init__(
+            pvinstallations,
+            timezone,
+            min_time_between_api_calls,
+            api_delay,
+            target_resolution=target_resolution,
+            native_resolution=60,
+            persistent_cache_directory=persistent_cache_directory,
+        )  # FCSolar provides hourly data
 
     def get_forecast_from_raw_data(self) -> dict:
         """ Get hourly forecast from previously fetched raw data """

--- a/src/batcontrol/forecastsolar/solar.py
+++ b/src/batcontrol/forecastsolar/solar.py
@@ -15,7 +15,8 @@ class ForecastSolar:
                               min_time_between_api_calls,
                               api_delay=0,
                               requested_provider='fcsolarapi',
-                              target_resolution: int = 60) -> ForecastSolarInterface:
+                              target_resolution: int = 60,
+                              persistent_cache_directory=None) -> ForecastSolarInterface:
         """ Select and configure a solar forecast provider based on the given configuration
 
         Args:
@@ -26,6 +27,7 @@ class ForecastSolar:
             requested_provider: Provider name ('fcsolarapi', 'evcc-solar',
                                 'homeassistant-solar-forecast-ml', 'solcast')
             target_resolution: Target resolution in minutes (15 or 60)
+            persistent_cache_directory: Optional directory for restart-safe raw data
 
         Raises:
             RuntimeError: If provider is unknown
@@ -33,8 +35,14 @@ class ForecastSolar:
         """
         provider = None
         if requested_provider.lower() == 'fcsolarapi':
-            provider = FCSolar(config, timezone, min_time_between_api_calls,
-                               api_delay, target_resolution)
+            provider = FCSolar(
+                config,
+                timezone,
+                min_time_between_api_calls,
+                api_delay,
+                target_resolution,
+                persistent_cache_directory=persistent_cache_directory,
+            )
         elif requested_provider.lower() == 'evcc-solar':
             provider = EvccSolar(config, timezone, min_time_between_api_calls,
                                  api_delay, target_resolution)

--- a/tests/batcontrol/fetcher/test_relaxed_caching_persistence.py
+++ b/tests/batcontrol/fetcher/test_relaxed_caching_persistence.py
@@ -1,0 +1,148 @@
+"""Persistence tests for the relaxed provider cache."""
+
+import os
+import stat
+
+import pytest
+
+from batcontrol.fetcher.relaxed_caching import CacheMissError, RelaxedCaching
+
+
+class MutableWallClock:
+    """Controllable wall clock for cache-age tests."""
+
+    def __init__(self, now=1_000_000.0):
+        self.now = now
+
+    def __call__(self):
+        return self.now
+
+
+def test_persisted_entry_survives_restart_with_original_age(tmp_path):
+    """A restarted process reloads a fresh entry without resetting its age."""
+    path = tmp_path / "forecast.json"
+    clock = MutableWallClock()
+    first = RelaxedCaching(persistence_path=path, wall_clock=clock)
+    first.store_new_entry({"result": "last-known-good"})
+
+    clock.now += 2 * 3600
+    restarted = RelaxedCaching(persistence_path=path, wall_clock=clock)
+
+    assert restarted.get_last_entry() == {"result": "last-known-good"}
+    assert restarted.get_cache_info()["cache_age_seconds"] == 2 * 3600
+
+
+def test_wall_clock_jump_does_not_change_memory_only_ttl_behavior():
+    """Persistence support leaves the existing monotonic memory TTL intact."""
+    clock = MutableWallClock()
+    cache = RelaxedCaching(wall_clock=clock)
+    cache.store_new_entry({"result": "in-memory"})
+
+    clock.now += 12 * 3600
+
+    assert cache.get_last_entry() == {"result": "in-memory"}
+
+
+def test_persisted_entry_is_usable_just_before_twelve_hours(tmp_path):
+    """Reloaded data keeps the existing strict less-than-12-hour boundary."""
+    path = tmp_path / "forecast.json"
+    clock = MutableWallClock()
+    first = RelaxedCaching(persistence_path=path, wall_clock=clock)
+    first.store_new_entry({"result": "last-known-good"})
+
+    clock.now += 12 * 3600 - 0.001
+    restarted = RelaxedCaching(persistence_path=path, wall_clock=clock)
+
+    assert restarted.get_last_entry() == {"result": "last-known-good"}
+
+
+def test_persisted_entry_expires_at_original_twelve_hour_boundary(tmp_path):
+    """Restarting cannot extend an entry beyond its original TTL."""
+    path = tmp_path / "forecast.json"
+    clock = MutableWallClock()
+    first = RelaxedCaching(persistence_path=path, wall_clock=clock)
+    first.store_new_entry({"result": "last-known-good"})
+
+    clock.now += 12 * 3600
+    restarted = RelaxedCaching(persistence_path=path, wall_clock=clock)
+
+    with pytest.raises(CacheMissError):
+        restarted.get_last_entry()
+
+
+def test_malformed_persisted_entry_is_ignored_without_leaking_contents(
+        tmp_path, caplog):
+    """A corrupt cache behaves as a miss and does not expose its contents."""
+    path = tmp_path / "forecast.json"
+    path.write_text("not-json-secret-key", encoding="utf-8")
+
+    cache = RelaxedCaching(persistence_path=path)
+
+    with pytest.raises(CacheMissError):
+        cache.get_last_entry()
+    assert "secret-key" not in caplog.text
+
+
+def test_failed_atomic_replace_keeps_previous_disk_entry_and_new_memory_entry(
+        tmp_path, mocker):
+    """A disk failure cannot discard either the old file or new in-memory data."""
+    path = tmp_path / "forecast.json"
+    clock = MutableWallClock()
+    cache = RelaxedCaching(persistence_path=path, wall_clock=clock)
+    cache.store_new_entry({"value": "old"})
+    original_file = path.read_bytes()
+
+    clock.now += 60
+    mocker.patch(
+        "batcontrol.fetcher.relaxed_caching.os.replace",
+        side_effect=OSError("simulated replace failure"),
+    )
+    cache.store_new_entry({"value": "new"})
+
+    assert cache.get_last_entry() == {"value": "new"}
+    assert path.read_bytes() == original_file
+
+    restarted = RelaxedCaching(persistence_path=path, wall_clock=clock)
+    assert restarted.get_last_entry() == {"value": "old"}
+
+
+def test_persistent_file_is_private(tmp_path):
+    """Raw provider data is written with owner-only permissions on POSIX."""
+    path = tmp_path / "forecast.json"
+    cache = RelaxedCaching(persistence_path=path)
+
+    cache.store_new_entry({"result": "forecast"})
+
+    if os.name == "posix":
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_clear_cache_removes_persisted_entry(tmp_path):
+    """Clearing a cache removes both memory and its restart copy."""
+    path = tmp_path / "forecast.json"
+    cache = RelaxedCaching(persistence_path=path)
+    cache.store_new_entry({"result": "forecast"})
+
+    cache.clear_cache()
+
+    assert not path.exists()
+    with pytest.raises(CacheMissError):
+        cache.get_last_entry()
+
+
+def test_orphaned_temporary_file_is_not_loaded(tmp_path):
+    """An interrupted write cannot become the restart cache."""
+    path = tmp_path / "forecast.json"
+    temporary_path = tmp_path / "forecast.json.tmp"
+    temporary_path.write_text(
+        '{"stored_at": 1000000, "data": {"bad": true}}',
+        encoding="utf-8",
+    )
+
+    cache = RelaxedCaching(
+        persistence_path=path,
+        wall_clock=MutableWallClock(),
+    )
+
+    with pytest.raises(CacheMissError):
+        cache.get_last_entry()

--- a/tests/batcontrol/forecastsolar/test_baseclass.py
+++ b/tests/batcontrol/forecastsolar/test_baseclass.py
@@ -18,11 +18,13 @@ class ConcreteForecastSolar(ForecastSolarBaseclass):
 
     def __init__(self, pvinstallations, timezone, min_time_between_API_calls,
                  delay_evaluation_by_seconds, mock_provider_func=None, mock_forecast_func=None,
-                 target_resolution=60, native_resolution=60):
+                 target_resolution=60, native_resolution=60,
+                 persistent_cache_directory=None):
         super().__init__(pvinstallations, timezone, min_time_between_API_calls,
                         delay_evaluation_by_seconds,
                         target_resolution=target_resolution,
-                        native_resolution=native_resolution)
+                        native_resolution=native_resolution,
+                        persistent_cache_directory=persistent_cache_directory)
         self.mock_provider_func = mock_provider_func
         self.mock_forecast_func = mock_forecast_func
 
@@ -87,6 +89,17 @@ class TestForecastSolarBaseclass:
                 timezone,
                 min_time_between_API_calls=900,
                 delay_evaluation_by_seconds=0
+            )
+
+    def test_initialization_without_name_with_persistence(self, timezone, tmp_path):
+        """Persistence keeps the existing missing-name validation contract."""
+        with pytest.raises(ValueError, match="'name' key"):
+            ConcreteForecastSolar(
+                [{'no_name': 'value'}],
+                timezone,
+                min_time_between_API_calls=900,
+                delay_evaluation_by_seconds=0,
+                persistent_cache_directory=tmp_path,
             )
 
     def test_store_and_get_raw_data(self, baseclass_instance):

--- a/tests/batcontrol/forecastsolar/test_fcsolar.py
+++ b/tests/batcontrol/forecastsolar/test_fcsolar.py
@@ -63,6 +63,68 @@ def test_refresh_keeps_cached_data_on_request_error(instance, mocker, caplog):
     assert 'secret-key' not in caplog.text
 
 
+def test_restart_uses_persisted_response_after_request_error(
+        instance, tmp_path, mocker, caplog):
+    """A fresh raw response survives restart and a provider network failure."""
+    first = FCSolar(
+        instance.pvinstallations,
+        instance.timezone,
+        min_time_between_api_calls=900,
+        persistent_cache_directory=tmp_path,
+    )
+    cached_response = {'result': 'last-known-good'}
+    first.store_raw_data('roof', cached_response)
+
+    restarted = FCSolar(
+        instance.pvinstallations,
+        instance.timezone,
+        min_time_between_api_calls=900,
+        persistent_cache_directory=tmp_path,
+    )
+    mocker.patch(
+        'batcontrol.forecastsolar.fcsolar.requests.get',
+        side_effect=requests.exceptions.ConnectionError(
+            'request failed for https://api.forecast.solar/secret-key/estimate'),
+    )
+
+    restarted.refresh_data()
+
+    assert restarted.get_raw_data('roof') == cached_response
+    cache_files = list(tmp_path.glob('*.json'))
+    assert len(cache_files) == 1
+    assert 'roof' not in cache_files[0].name
+    assert 'secret-key' not in caplog.text
+
+
+def test_persistent_cache_keeps_one_file_per_installation(instance, tmp_path):
+    """Independent arrays retain independent raw provider responses."""
+    installations = [
+        instance.pvinstallations[0],
+        dict(instance.pvinstallations[0], name='garage', azimuth=-40),
+    ]
+    first = FCSolar(
+        installations,
+        instance.timezone,
+        min_time_between_api_calls=900,
+        persistent_cache_directory=tmp_path,
+    )
+    first.store_raw_data('roof', {'result': 'roof-forecast'})
+    first.store_raw_data('garage', {'result': 'garage-forecast'})
+
+    restarted = FCSolar(
+        installations,
+        instance.timezone,
+        min_time_between_api_calls=900,
+        persistent_cache_directory=tmp_path,
+    )
+
+    assert restarted.get_all_raw_data() == {
+        'roof': {'result': 'roof-forecast'},
+        'garage': {'result': 'garage-forecast'},
+    }
+    assert len(list(tmp_path.glob('*.json'))) == 2
+
+
 class MutableClock:
     """Controllable monotonic clock for replaying the cache boundary."""
 
@@ -121,6 +183,46 @@ def forecast_from_cached_response(instance, mocker, fixed_now):
     forecast = instance.get_forecast_from_raw_data()
     mocker.stop(mocked_datetime)
     return forecast
+
+
+def test_august_22_restart_reloads_forecast_before_provider_failure(
+        instance, tmp_path, mocker, caplog):
+    """Replay the 05:21 restart that previously erased the fresh forecast."""
+    cached_response = {
+        'message': {'info': {'time': '2026-08-22T04:51:04+02:00'}},
+        'result': {
+            '2026-08-22T06:00:00+02:00': 420,
+            '2026-08-22T07:00:00+02:00': 860,
+            '2026-08-22T08:00:00+02:00': 1330,
+        },
+    }
+    first = FCSolar(
+        instance.pvinstallations,
+        instance.timezone,
+        min_time_between_api_calls=900,
+        persistent_cache_directory=tmp_path,
+    )
+    first.store_raw_data('roof', cached_response)
+
+    restarted = FCSolar(
+        instance.pvinstallations,
+        instance.timezone,
+        min_time_between_api_calls=900,
+        persistent_cache_directory=tmp_path,
+    )
+    mocker.patch(
+        'batcontrol.forecastsolar.fcsolar.requests.get',
+        side_effect=requests.exceptions.ConnectionError(
+            'request failed for https://api.forecast.solar/secret-key/estimate'),
+    )
+    restarted.refresh_data()
+    fixed_now = instance.timezone.localize(
+        datetime.datetime(2026, 8, 22, 5, 22))
+
+    production = forecast_from_cached_response(restarted, mocker, fixed_now)
+
+    assert production == {0: 420, 1: 860, 2: 1330}
+    assert 'secret-key' not in caplog.text
 
 
 def test_july_24_network_failure_keeps_unexpired_forecast_available(

--- a/tests/batcontrol/forecastsolar/test_solar_factory.py
+++ b/tests/batcontrol/forecastsolar/test_solar_factory.py
@@ -1,0 +1,31 @@
+"""Tests for solar-provider factory cache wiring."""
+
+from unittest.mock import patch
+
+import pytz
+
+from batcontrol.forecastsolar.solar import ForecastSolar
+
+
+@patch("batcontrol.forecastsolar.solar.FCSolar")
+def test_fcsolar_receives_persistent_cache_directory(mock_fcsolar, tmp_path):
+    """Only forecast.solar receives the restart-cache directory."""
+    installations = [{"name": "roof"}]
+    timezone = pytz.timezone("Europe/Warsaw")
+
+    ForecastSolar.create_solar_provider(
+        installations,
+        timezone,
+        min_time_between_api_calls=900,
+        requested_provider="fcsolarapi",
+        persistent_cache_directory=tmp_path,
+    )
+
+    mock_fcsolar.assert_called_once_with(
+        installations,
+        timezone,
+        900,
+        0,
+        60,
+        persistent_cache_directory=tmp_path,
+    )

--- a/tests/batcontrol/test_core.py
+++ b/tests/batcontrol/test_core.py
@@ -238,6 +238,32 @@ class TestTimeResolutionString:
         assert isinstance(bc.time_resolution, int)
         assert bc.time_resolution == expected_int
 
+    @patch('batcontrol.core.tariff_factory.create_tarif_provider')
+    @patch('batcontrol.core.inverter_factory.create_inverter')
+    @patch('batcontrol.core.solar_factory.create_solar_provider')
+    @patch('batcontrol.core.consumption_factory.create_consumption')
+    def test_forecast_cache_directory_is_forwarded_to_solar_factory(
+        self, mock_consumption, mock_solar, mock_inverter_factory, mock_tariff,
+        base_mock_config, tmp_path
+    ):
+        """The CLI-selected state directory reaches the solar provider."""
+        mock_inverter = MagicMock()
+        mock_inverter.get_max_capacity = MagicMock(return_value=10000)
+        mock_inverter_factory.return_value = mock_inverter
+        mock_tariff.return_value = MagicMock()
+        mock_solar.return_value = MagicMock()
+        mock_consumption.return_value = MagicMock()
+
+        Batcontrol(
+            base_mock_config,
+            forecast_cache_directory=tmp_path,
+        )
+
+        assert (
+            mock_solar.call_args.kwargs['persistent_cache_directory']
+            == tmp_path
+        )
+
     @pytest.mark.parametrize('resolution_str', ['60', '15'])
     def test_logic_factory_accepts_string_resolution_as_int(self, resolution_str):
         """Logic factory must produce a valid logic instance when given an int resolution"""

--- a/tests/batcontrol/test_main.py
+++ b/tests/batcontrol/test_main.py
@@ -1,0 +1,12 @@
+"""Tests for command-line runtime paths."""
+
+from batcontrol.__main__ import get_forecast_cache_directory
+
+
+def test_forecast_cache_directory_is_beside_config_file(tmp_path):
+    """Persistent provider state follows the selected configuration file."""
+    config_file = tmp_path / "deployment" / "live.yaml"
+
+    result = get_forecast_cache_directory(config_file)
+
+    assert result == config_file.parent.resolve() / "forecast_cache"


### PR DESCRIPTION
The existing forecast.solar cache handles provider outages only while the batcontrol process stays alive.

This happened in a real installation: forecast.solar became unavailable, but the in-memory cache kept normal decisions working. An unrelated local network error then crashed and restarted batcontrol. The new process had no cache, even though the last forecast was only about 30 minutes old, and later entered the existing no-data fallback.

This change saves the latest successful raw response for each PV installation and reloads it after restart. It preserves the original fetch timestamp, so restart does not renew the existing 12-hour TTL.